### PR TITLE
Add decorator pattern into BuildResultDTO to show compilation time in seconds

### DIFF
--- a/src/main/java/pt/isec/mei/das/controller/BuildResultController.java
+++ b/src/main/java/pt/isec/mei/das/controller/BuildResultController.java
@@ -1,5 +1,6 @@
 package pt.isec.mei.das.controller;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,28 +8,34 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import pt.isec.mei.das.dto.BuildResultDTO;
+import pt.isec.mei.das.dto.BuildResultDecoratedWithTimeInSeconds;
 import pt.isec.mei.das.service.BuildService;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/builds")
 @AllArgsConstructor
 public class BuildResultController {
-    private final BuildService buildService;
+  private final BuildService buildService;
 
-    @GetMapping
-    public ResponseEntity<List<BuildResultDTO>> getAllBuildResults() {
-        return ResponseEntity.ok(buildService.findAllBuildResults());
-    }
+  @GetMapping
+  public ResponseEntity<List<BuildResultDTO>> getAllBuildResults() {
+    return ResponseEntity.ok(buildService.findAllBuildResults());
+  }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<BuildResultDTO> getBuildResultForProject(@PathVariable("id") Long id) {
-        return ResponseEntity.ok(buildService.findBuildResultById(id));
-    }
+  @GetMapping("/{id}")
+  public ResponseEntity<BuildResultDTO> getBuildResultForProject(@PathVariable("id") Long id) {
+    return ResponseEntity.ok(buildService.findBuildResultById(id));
+  }
 
-    @GetMapping("/project/{projectId}")
-    public ResponseEntity<List<BuildResultDTO>> getBuildResult(@PathVariable("projectId") Long projectId) {
-        return ResponseEntity.ok(buildService.findBuildResultsByProjectId(projectId));
-    }
+  @GetMapping("/{id}/time-converted")
+  public ResponseEntity<BuildResultDecoratedWithTimeInSeconds> getDetailedBuildResultForProject(
+      @PathVariable("id") Long id) {
+    return ResponseEntity.ok(buildService.findDetailedBuildResultById(id));
+  }
+
+  @GetMapping("/project/{projectId}")
+  public ResponseEntity<List<BuildResultDTO>> getBuildResult(
+      @PathVariable("projectId") Long projectId) {
+    return ResponseEntity.ok(buildService.findBuildResultsByProjectId(projectId));
+  }
 }

--- a/src/main/java/pt/isec/mei/das/controller/BuildResultController.java
+++ b/src/main/java/pt/isec/mei/das/controller/BuildResultController.java
@@ -8,7 +8,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import pt.isec.mei.das.dto.AbstractBuildResultDecorator;
 import pt.isec.mei.das.dto.BuildResultDTO;
+import pt.isec.mei.das.dto.BuildResultDecoratedWithTimeInSeconds;
+import pt.isec.mei.das.dto.BuildResultDecorator;
 import pt.isec.mei.das.service.BuildService;
 
 @RestController
@@ -34,21 +37,22 @@ public class BuildResultController {
 
   @GetMapping("/{id}/time-converted")
   public ResponseEntity<?> getDetailedBuildResultForProject(@PathVariable("id") Long id) {
-
     BuildResultDTO buildResultById = buildService.findBuildResultById(id);
 
     if (buildResultById.getCompilationStatus().equals("NOT_STARTED")
-        || buildResultById.getCompilationStatus().equals("IN_PROGRESS")) {
+            || buildResultById.getCompilationStatus().equals("IN_PROGRESS")) {
       String response =
-          "Your process didn't finish. You can check the status at: http://localhost:8080/builds/"
-              + id
-              + "/status";
+              "Your process didn't finish. You can check the status at: http://localhost:8080/builds/"
+                      + id
+                      + "/status";
 
       return ResponseEntity.status(HttpStatus.ACCEPTED).body(response);
     }
 
-    return ResponseEntity.ok(buildService.findDetailedBuildResultById(id));
+    BuildResultDecorator decoratedResult = new BuildResultDecoratedWithTimeInSeconds(buildResultById);
+    return ResponseEntity.ok(decoratedResult);
   }
+
 
   @GetMapping("/project/{projectId}")
   public ResponseEntity<List<BuildResultDTO>> getBuildResult(

--- a/src/main/java/pt/isec/mei/das/controller/BuildResultController.java
+++ b/src/main/java/pt/isec/mei/das/controller/BuildResultController.java
@@ -2,13 +2,13 @@ package pt.isec.mei.das.controller;
 
 import java.util.List;
 import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import pt.isec.mei.das.dto.BuildResultDTO;
-import pt.isec.mei.das.dto.BuildResultDecoratedWithTimeInSeconds;
 import pt.isec.mei.das.service.BuildService;
 
 @RestController
@@ -27,9 +27,26 @@ public class BuildResultController {
     return ResponseEntity.ok(buildService.findBuildResultById(id));
   }
 
+  @GetMapping("/{id}/status")
+  public ResponseEntity<String> getStatusBuildResultForProject(@PathVariable("id") Long id) {
+    return ResponseEntity.ok(buildService.findStatusBuildResultById(id));
+  }
+
   @GetMapping("/{id}/time-converted")
-  public ResponseEntity<BuildResultDecoratedWithTimeInSeconds> getDetailedBuildResultForProject(
-      @PathVariable("id") Long id) {
+  public ResponseEntity<?> getDetailedBuildResultForProject(@PathVariable("id") Long id) {
+
+    BuildResultDTO buildResultById = buildService.findBuildResultById(id);
+
+    if (buildResultById.getCompilationStatus().equals("NOT_STARTED")
+        || buildResultById.getCompilationStatus().equals("IN_PROGRESS")) {
+      String response =
+          "Your process didn't finish. You can check the status at: http://localhost:8080/builds/"
+              + id
+              + "/status";
+
+      return ResponseEntity.status(HttpStatus.ACCEPTED).body(response);
+    }
+
     return ResponseEntity.ok(buildService.findDetailedBuildResultById(id));
   }
 

--- a/src/main/java/pt/isec/mei/das/dto/AbstractBuildResultDecorator.java
+++ b/src/main/java/pt/isec/mei/das/dto/AbstractBuildResultDecorator.java
@@ -1,0 +1,46 @@
+package pt.isec.mei.das.dto;
+
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+public abstract class AbstractBuildResultDecorator implements BuildResultDecorator {
+
+  protected BuildResultDecorator decoratedBuildResult;
+
+  @Override
+  public Long getId() {
+    return decoratedBuildResult.getId();
+  }
+
+  @Override
+  public Long getProjectId() {
+    return decoratedBuildResult.getProjectId();
+  }
+
+  @Override
+  public String getCompilationStatus() {
+    return decoratedBuildResult.getCompilationStatus();
+  }
+
+  @Override
+  public String getExecutableFilePath() {
+    return decoratedBuildResult.getExecutableFilePath();
+  }
+
+  @Override
+  public String getBuildLogs() {
+    return decoratedBuildResult.getBuildLogs();
+  }
+
+  @Override
+  public LocalDateTime getTimestamp() {
+    return decoratedBuildResult.getTimestamp();
+  }
+
+  @Override
+  public Long getCompilationTimeMs() {
+    return decoratedBuildResult.getCompilationTimeMs();
+  }
+}

--- a/src/main/java/pt/isec/mei/das/dto/BuildResultDTO.java
+++ b/src/main/java/pt/isec/mei/das/dto/BuildResultDTO.java
@@ -1,23 +1,21 @@
 package pt.isec.mei.das.dto;
 
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import pt.isec.mei.das.enums.CompilationStatus;
-
-import java.time.LocalDateTime;
 
 @Data
 @AllArgsConstructor
 @EqualsAndHashCode
 @Builder
-public class BuildResultDTO {
-    private Long id;
-    private Long projectId;
-    private String sourceCodeHash;
-    private String compilationStatus;
-    private String executableFilePath;
-    private String buildLogs;
-    private LocalDateTime timestamp;
+public class BuildResultDTO implements BuildResultDecorator {
+  private Long id;
+  private Long projectId;
+  private Long compilationTimeMs;
+  private String compilationStatus;
+  private String executableFilePath;
+  private String buildLogs;
+  private LocalDateTime timestamp;
 }

--- a/src/main/java/pt/isec/mei/das/dto/BuildResultDTO.java
+++ b/src/main/java/pt/isec/mei/das/dto/BuildResultDTO.java
@@ -1,5 +1,7 @@
 package pt.isec.mei.das.dto;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/pt/isec/mei/das/dto/BuildResultDecoratedWithTimeInSeconds.java
+++ b/src/main/java/pt/isec/mei/das/dto/BuildResultDecoratedWithTimeInSeconds.java
@@ -1,0 +1,56 @@
+package pt.isec.mei.das.dto;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class BuildResultDecoratedWithTimeInSeconds implements BuildResultDecorator {
+
+  private BuildResultDTO buildResultDTO;
+
+  @Override
+  public Long getId() {
+    return buildResultDTO.getId();
+  }
+
+  @Override
+  public Long getProjectId() {
+    return buildResultDTO.getProjectId();
+  }
+
+  @Override
+  public String getCompilationStatus() {
+    return buildResultDTO.getCompilationStatus();
+  }
+
+  @Override
+  public String getExecutableFilePath() {
+    return buildResultDTO.getExecutableFilePath();
+  }
+
+  @Override
+  public String getBuildLogs() {
+    return buildResultDTO.getBuildLogs();
+  }
+
+  @Override
+  public LocalDateTime getTimestamp() {
+    return buildResultDTO.getTimestamp();
+  }
+
+  @Override
+  public Long getCompilationTimeMs() {
+    return buildResultDTO.getCompilationTimeMs();
+  }
+
+  public String getCompilationTimeSeconds() {
+
+    BigDecimal timeInSeconds =
+        BigDecimal.valueOf(buildResultDTO.getCompilationTimeMs())
+            .divide(BigDecimal.valueOf(1000), 3, RoundingMode.CEILING);
+
+    return "COMPILATION TIME IN SECONDS: " + timeInSeconds;
+  }
+}

--- a/src/main/java/pt/isec/mei/das/dto/BuildResultDecoratedWithTimeInSeconds.java
+++ b/src/main/java/pt/isec/mei/das/dto/BuildResultDecoratedWithTimeInSeconds.java
@@ -5,50 +5,16 @@ import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 
-@AllArgsConstructor
-public class BuildResultDecoratedWithTimeInSeconds implements BuildResultDecorator {
+public class BuildResultDecoratedWithTimeInSeconds extends AbstractBuildResultDecorator {
 
-  private BuildResultDTO buildResultDTO;
-
-  @Override
-  public Long getId() {
-    return buildResultDTO.getId();
-  }
-
-  @Override
-  public Long getProjectId() {
-    return buildResultDTO.getProjectId();
-  }
-
-  @Override
-  public String getCompilationStatus() {
-    return buildResultDTO.getCompilationStatus();
-  }
-
-  @Override
-  public String getExecutableFilePath() {
-    return buildResultDTO.getExecutableFilePath();
-  }
-
-  @Override
-  public String getBuildLogs() {
-    return buildResultDTO.getBuildLogs();
-  }
-
-  @Override
-  public LocalDateTime getTimestamp() {
-    return buildResultDTO.getTimestamp();
-  }
-
-  @Override
-  public Long getCompilationTimeMs() {
-    return buildResultDTO.getCompilationTimeMs();
+  public BuildResultDecoratedWithTimeInSeconds(BuildResultDecorator decoratedBuildResult) {
+    super(decoratedBuildResult);
   }
 
   public String getCompilationTimeSeconds() {
 
     BigDecimal timeInSeconds =
-        BigDecimal.valueOf(buildResultDTO.getCompilationTimeMs())
+        BigDecimal.valueOf(decoratedBuildResult.getCompilationTimeMs())
             .divide(BigDecimal.valueOf(1000), 3, RoundingMode.CEILING);
 
     return "COMPILATION TIME IN SECONDS: " + timeInSeconds;

--- a/src/main/java/pt/isec/mei/das/dto/BuildResultDecorator.java
+++ b/src/main/java/pt/isec/mei/das/dto/BuildResultDecorator.java
@@ -1,0 +1,19 @@
+package pt.isec.mei.das.dto;
+
+import java.time.LocalDateTime;
+
+public interface BuildResultDecorator {
+  Long getId();
+
+  Long getProjectId();
+
+  String getCompilationStatus();
+
+  String getExecutableFilePath();
+
+  String getBuildLogs();
+
+  LocalDateTime getTimestamp();
+
+  Long getCompilationTimeMs();
+}

--- a/src/main/java/pt/isec/mei/das/entity/BuildResult.java
+++ b/src/main/java/pt/isec/mei/das/entity/BuildResult.java
@@ -8,13 +8,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-
 import java.time.LocalDateTime;
-
-import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
-import pt.isec.mei.das.enums.CompilationStatus;
 
 @Entity
 @Getter
@@ -22,27 +18,27 @@ import pt.isec.mei.das.enums.CompilationStatus;
 @Table(name = "BUILD_RESULT")
 public class BuildResult {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "build_result_id")
-    private long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "build_result_id")
+  private long id;
 
-    @ManyToOne
-    @JoinColumn(name = "project_id", nullable = false)
-    private Project project;
+  @ManyToOne
+  @JoinColumn(name = "project_id", nullable = false)
+  private Project project;
 
-    @Column(name = "source_code_hash")
-    private String sourceCodeHash;
+  @Column(name = "compilation_time_ms")
+  private Long compilationTimeInMs;
 
-    @Column(name = "compilation_status")
-    private String compilationStatus;
+  @Column(name = "compilation_status")
+  private String compilationStatus;
 
-    @Column(name = "executable_file_path")
-    private String executableFilePath;
+  @Column(name = "executable_file_path")
+  private String executableFilePath;
 
-    @Column(name = "build_logs")
-    private String buildLogs;
+  @Column(name = "build_logs")
+  private String buildLogs;
 
-    @Column(name = "timestamp")
-    private LocalDateTime timestamp;
+  @Column(name = "timestamp")
+  private LocalDateTime timestamp;
 }

--- a/src/main/java/pt/isec/mei/das/repository/BuildResultRepository.java
+++ b/src/main/java/pt/isec/mei/das/repository/BuildResultRepository.java
@@ -1,14 +1,21 @@
 package pt.isec.mei.das.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import pt.isec.mei.das.entity.BuildResult;
 import pt.isec.mei.das.entity.Project;
 
-import java.util.List;
-
 @Repository
 public interface BuildResultRepository extends JpaRepository<BuildResult, Long> {
 
-    List<BuildResult> findBuildResultByProject(Project project);
+  List<BuildResult> findBuildResultByProject(Project project);
+
+  @Query(
+      value =
+          """
+          select b.compilationStatus from BuildResult b where b.id = :id
+          """)
+  String findStatusById(Long id);
 }

--- a/src/main/java/pt/isec/mei/das/service/BuildService.java
+++ b/src/main/java/pt/isec/mei/das/service/BuildService.java
@@ -1,11 +1,18 @@
 package pt.isec.mei.das.service;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pt.isec.mei.das.config.FileStorageProperties;
 import pt.isec.mei.das.dto.BuildResultDTO;
+import pt.isec.mei.das.dto.BuildResultDecoratedWithTimeInSeconds;
 import pt.isec.mei.das.entity.BuildResult;
 import pt.isec.mei.das.entity.Project;
 import pt.isec.mei.das.enums.CompilationStatus;
@@ -15,135 +22,182 @@ import pt.isec.mei.das.repository.ProjectRepository;
 import pt.isec.mei.das.service.compile.Compiler;
 import pt.isec.mei.das.service.compile.CompilerFactory;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.time.LocalDateTime;
-import java.util.List;
-
 @Slf4j
 @Service
 @AllArgsConstructor
 public class BuildService {
 
-    private final ProjectRepository projectRepository;
-    private final FileStorageProperties fileStorageProperties;
-    private final BuildResultRepository buildResultRepository;
+  private final ProjectRepository projectRepository;
+  private final FileStorageProperties fileStorageProperties;
+  private final BuildResultRepository buildResultRepository;
 
-    @Transactional
-    public BuildResultDTO submitBuild(long projectId) {
-        Project project = projectRepository.findById(projectId)
-                .orElseThrow(() -> new EntityNotFoundException("Project not found with id: " + projectId));
+  @Transactional
+  public BuildResultDTO submitBuild(long projectId) {
+    Project project =
+        projectRepository
+            .findById(projectId)
+            .orElseThrow(
+                () -> new EntityNotFoundException("Project not found with id: " + projectId));
 
-        BuildResult buildResult = new BuildResult();
-        buildResult.setProject(project);
-        buildResult.setCompilationStatus(CompilationStatus.IN_PROGRESS.name());
-        buildResult.setTimestamp(LocalDateTime.now());
-        buildResultRepository.save(buildResult);
+    BuildResult buildResult = new BuildResult();
+    buildResult.setProject(project);
+    buildResult.setCompilationStatus(CompilationStatus.IN_PROGRESS.name());
+    buildResult.setTimestamp(LocalDateTime.now());
+    buildResultRepository.save(buildResult);
 
-        BuildManager.getInstance().enqueue(buildResult);
+    BuildManager.getInstance().enqueue(buildResult);
 
-        log.info("Project {} is added to the build queue", project.getName());
+    log.info("Project {} is added to the build queue", project.getName());
 
-        return BuildResultDTO.builder()
-                .id(buildResult.getId())
-                .projectId(buildResult.getProject().getId())
-                .compilationStatus(buildResult.getCompilationStatus())
-                .timestamp(buildResult.getTimestamp())
-                .build();
+    return BuildResultDTO.builder()
+        .id(buildResult.getId())
+        .projectId(buildResult.getProject().getId())
+        .compilationStatus(buildResult.getCompilationStatus())
+        .timestamp(buildResult.getTimestamp())
+        .build();
+  }
+
+  @Transactional
+  public void build(BuildResult build) {
+
+    long start = System.currentTimeMillis();
+    System.out.println("Start: " + start);
+
+    String outputFileName = build.getId() + "_" + build.getProject().getName() + "_compiled";
+    File outputDir = new File(fileStorageProperties.getCompiledDir());
+
+    Compiler compiler =
+        CompilerFactory.getCompiler(
+            build.getProject().getProjectLanguage().getProgrammingLanguage());
+
+    try {
+      Process process =
+          compiler.compile(build.getProject().getFilePath(), outputFileName, outputDir);
+      int exitCode = process.waitFor();
+
+      String buildLogs = getBuildLogs(process);
+
+      BuildResult buildResult =
+          buildResultRepository
+              .findById(build.getId())
+              .orElseThrow(
+                  () ->
+                      new EntityNotFoundException(
+                          "BuildResults not found for project with id: "
+                              + build.getProject().getId()));
+      buildResult.setBuildLogs(buildLogs);
+      buildResult.setTimestamp(LocalDateTime.now());
+
+      if (exitCode == 0) {
+        buildResult.setExecutableFilePath(new File(outputDir, outputFileName).getAbsolutePath());
+        buildResult.setCompilationStatus(CompilationStatus.SUCCESS.name());
+      } else {
+        buildResult.setCompilationStatus(CompilationStatus.FAILURE.name());
+      }
+
+      long end = System.currentTimeMillis();
+      System.out.println("End: " + end);
+      long time = (end - start);
+      System.out.println("Time in millis: " + time);
+
+      buildResult.setCompilationTimeInMs(time);
+
+      buildResultRepository.save(buildResult);
+    } catch (IOException | InterruptedException e) {
+      e.printStackTrace();
+      throw new RuntimeException(e);
     }
+  }
 
-    @Transactional
-    public void build(BuildResult build) {
-        String outputFileName = build.getId() + "_" + build.getProject().getName() + "_compiled";
-        File outputDir = new File(fileStorageProperties.getCompiledDir());
-
-        Compiler compiler = CompilerFactory.getCompiler(build.getProject().getProjectLanguage().getProgrammingLanguage());
-
-        try {
-            Process process = compiler.compile(build.getProject().getFilePath(), outputFileName, outputDir);
-            int exitCode = process.waitFor();
-
-            String buildLogs = getBuildLogs(process);
-
-            BuildResult buildResult = buildResultRepository.findById(build.getId())
-                    .orElseThrow(() -> new EntityNotFoundException("BuildResults not found for project with id: " + build.getProject().getId()));
-            buildResult.setBuildLogs(buildLogs);
-            buildResult.setTimestamp(LocalDateTime.now());
-
-            if (exitCode == 0) {
-                buildResult.setExecutableFilePath(new File(outputDir, outputFileName).getAbsolutePath());
-                buildResult.setCompilationStatus(CompilationStatus.SUCCESS.name());
-            } else {
-                buildResult.setCompilationStatus(CompilationStatus.FAILURE.name());
-            }
-            buildResultRepository.save(buildResult);
-        } catch (IOException | InterruptedException e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-        }
+  public List<BuildResultDTO> findBuildResultsByProjectId(Long projectId) {
+    Project project =
+        projectRepository
+            .findById(projectId)
+            .orElseThrow(
+                () -> new EntityNotFoundException("Project not found with id: " + projectId));
+    List<BuildResult> buildResults = buildResultRepository.findBuildResultByProject(project);
+    if (buildResults.isEmpty()) {
+      throw new EntityNotFoundException("BuildResult not found for project with id: " + projectId);
     }
+    return buildResults.stream()
+        .map(
+            b ->
+                BuildResultDTO.builder()
+                    .id(b.getId())
+                    .projectId(b.getProject().getId())
+                    .compilationTimeMs(b.getCompilationTimeInMs())
+                    .compilationStatus(b.getCompilationStatus())
+                    .executableFilePath(b.getExecutableFilePath())
+                    .buildLogs(b.getBuildLogs())
+                    .timestamp(b.getTimestamp())
+                    .build())
+        .toList();
+  }
 
-    public List<BuildResultDTO> findBuildResultsByProjectId(Long projectId) {
-        Project project = projectRepository.findById(projectId)
-                .orElseThrow(() -> new EntityNotFoundException("Project not found with id: " + projectId));
-        List<BuildResult> buildResults = buildResultRepository.findBuildResultByProject(project);
-        if (buildResults.isEmpty()) {
-            throw new EntityNotFoundException("BuildResult not found for project with id: " + projectId);
-        }
-        return buildResults.stream()
-                .map(b -> BuildResultDTO.builder()
-                                .id(b.getId())
-                                .projectId(b.getProject().getId())
-                                .sourceCodeHash(b.getSourceCodeHash())
-                                .compilationStatus(b.getCompilationStatus())
-                                .executableFilePath(b.getExecutableFilePath())
-                                .buildLogs(b.getBuildLogs())
-                                .timestamp(b.getTimestamp())
-                                .build())
-                .toList();
+  public List<BuildResultDTO> findAllBuildResults() {
+    List<BuildResult> buildResults = buildResultRepository.findAll();
+
+    return buildResults.stream()
+        .map(
+            b ->
+                BuildResultDTO.builder()
+                    .id(b.getId())
+                    .projectId(b.getProject().getId())
+                    .compilationTimeMs(b.getCompilationTimeInMs())
+                    .compilationStatus(b.getCompilationStatus())
+                    .executableFilePath(b.getExecutableFilePath())
+                    .buildLogs(b.getBuildLogs())
+                    .timestamp(b.getTimestamp())
+                    .build())
+        .toList();
+  }
+
+  public BuildResultDTO findBuildResultById(Long id) {
+    BuildResult buildResult =
+        buildResultRepository
+            .findById(id)
+            .orElseThrow(
+                () -> new EntityNotFoundException("BuildResult with id: " + id + " not found"));
+    return BuildResultDTO.builder()
+        .id(buildResult.getId())
+        .projectId(buildResult.getProject().getId())
+        .compilationTimeMs(buildResult.getCompilationTimeInMs())
+        .compilationStatus(buildResult.getCompilationStatus())
+        .executableFilePath(buildResult.getExecutableFilePath())
+        .buildLogs(buildResult.getBuildLogs())
+        .timestamp(buildResult.getTimestamp())
+        .build();
+  }
+
+  public BuildResultDecoratedWithTimeInSeconds findDetailedBuildResultById(Long id) {
+
+    BuildResult buildResult =
+        buildResultRepository
+            .findById(id)
+            .orElseThrow(
+                () -> new EntityNotFoundException("BuildResult with id: " + id + " not found"));
+
+    BuildResultDTO dto =
+        BuildResultDTO.builder()
+            .id(buildResult.getId())
+            .projectId(buildResult.getProject().getId())
+            .compilationTimeMs(buildResult.getCompilationTimeInMs())
+            .compilationStatus(buildResult.getCompilationStatus())
+            .executableFilePath(buildResult.getExecutableFilePath())
+            .buildLogs(buildResult.getBuildLogs())
+            .timestamp(buildResult.getTimestamp())
+            .build();
+
+    return new BuildResultDecoratedWithTimeInSeconds(dto);
+  }
+
+  private String getBuildLogs(Process process) throws IOException {
+    BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+    String line;
+    StringBuilder buildLogs = new StringBuilder();
+    while ((line = reader.readLine()) != null) {
+      buildLogs.append(line).append("\n");
     }
-
-    public List<BuildResultDTO> findAllBuildResults() {
-        List<BuildResult> buildResults = buildResultRepository.findAll();
-
-        return buildResults.stream()
-                .map(
-                        b ->
-                                BuildResultDTO.builder()
-                                        .id(b.getId())
-                                        .projectId(b.getProject().getId())
-                                        .sourceCodeHash(b.getSourceCodeHash())
-                                        .compilationStatus(b.getCompilationStatus())
-                                        .executableFilePath(b.getExecutableFilePath())
-                                        .buildLogs(b.getBuildLogs())
-                                        .timestamp(b.getTimestamp())
-                                        .build())
-                .toList();
-    }
-
-    public BuildResultDTO findBuildResultById(Long id) {
-        BuildResult buildResult = buildResultRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("BuildResult with id: " + id + " not found"));
-        return BuildResultDTO.builder()
-                .id(buildResult.getId())
-                .projectId(buildResult.getProject().getId())
-                .sourceCodeHash(buildResult.getSourceCodeHash())
-                .compilationStatus(buildResult.getCompilationStatus())
-                .executableFilePath(buildResult.getExecutableFilePath())
-                .buildLogs(buildResult.getBuildLogs())
-                .timestamp(buildResult.getTimestamp())
-                .build();
-    }
-
-    private String getBuildLogs(Process process) throws IOException {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
-        String line;
-        StringBuilder buildLogs = new StringBuilder();
-        while ((line = reader.readLine()) != null) {
-            buildLogs.append(line).append("\n");
-        }
-        return buildLogs.toString();
-    }
+    return buildLogs.toString();
+  }
 }

--- a/src/main/java/pt/isec/mei/das/service/BuildService.java
+++ b/src/main/java/pt/isec/mei/das/service/BuildService.java
@@ -169,6 +169,17 @@ public class BuildService {
         .build();
   }
 
+  public String findStatusBuildResultById(Long id) {
+
+    String status = buildResultRepository.findStatusById(id);
+
+    if (status == null) {
+      return String.format("Build id: %d not found", id);
+    }
+
+    return status;
+  }
+
   public BuildResultDecoratedWithTimeInSeconds findDetailedBuildResultById(Long id) {
 
     BuildResult buildResult =

--- a/src/main/java/pt/isec/mei/das/service/BuildService.java
+++ b/src/main/java/pt/isec/mei/das/service/BuildService.java
@@ -181,7 +181,6 @@ public class BuildService {
   }
 
   public BuildResultDecoratedWithTimeInSeconds findDetailedBuildResultById(Long id) {
-
     BuildResult buildResult =
         buildResultRepository
             .findById(id)

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -4,6 +4,6 @@ VALUES ('cpp', 'C++'), ('c', 'C');
 insert into PROJECT(project_language_id,name, created_at, file_path)
 VALUES (1,'Project 1', current_timestamp, 'example.cpp');
 
-insert into BUILD_RESULT(project_id, source_code_hash, compilation_status, executable_file_path, build_logs, timestamp)
-VALUES (1, 'source_code_hash', 'IN_PROGRESS', 'executable_file_path', 'build_logs', current_timestamp);
+insert into BUILD_RESULT(project_id, compilation_time_ms, compilation_status, executable_file_path, build_logs, timestamp)
+VALUES (1, 1000, 'IN_PROGRESS', 'executable_file_path', 'build_logs', current_timestamp);
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE BUILD_RESULT
 (
     build_result_id      BIGSERIAL PRIMARY KEY,
     project_id           BIGINT NOT NULL,
-    source_code_hash     VARCHAR(255),
+    compilation_time_ms  BIGINT,
     compilation_status   VARCHAR(255),
     executable_file_path VARCHAR(255),
     build_logs           TEXT,


### PR DESCRIPTION
**What I changed:**
- I inserted a new field in the table to record the difference from the beginning to the end of the build. This is done with variables in the build service.
- I deleted the "source_code_hash" column (it wasn't being used for anything).

**To test:**
- Create a project, trigger the build and wait for the start and end times to be printed on the console. The time in ms, saved in the database, will also appear.
- When this occurs, make a GET request to "http://localhost:8080/builds/{id}/time-converted", which will show the BuildResultDTO "decorated" with an additional field with the string "COMPILATION TIME IN SECONDS: ###".